### PR TITLE
.prettierrc 설정파일 parser 삭제

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,11 +5,9 @@
     "tabWidth": 2,
     "trailingComma": "es5",
     "printWidth": 80,
-    "parser": "babel",
     "bracketSpacing": true,
     "proseWrap": "preserve",
     "arrowParens": "always",
     "quoteProps": "as-needed"
-
   }
  


### PR DESCRIPTION
 - parser 설정이 barbel로 고정되어있어서 formatting 안먹는 케이스 발생
 - 아래 공식 문서 참고
 

_Note: Never put the parser option at the top level of your configuration. Only use it inside overrides. Otherwise you effectively disable Prettier’s automatic file extension based parser inference. This forces Prettier to use the parser you specified for all types of files – even when it doesn’t make sense, such as trying to parse a CSS file as JavaScript._
